### PR TITLE
Maintain dependencies and ci

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,19 @@
+name: Run test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.7', '3.0', '3.1']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
+      - name: Run Rspec
+        run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
----
-sudo: false
-language: ruby
-cache: bundler
-rvm:
-  - 2.6.2
-before_install: gem install bundler -v 1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
   specs:
     coderay (1.1.2)
     diff-lcs (1.3)
-    google-protobuf (3.8.0)
+    google-protobuf (3.21.12)
     method_source (0.9.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -34,7 +34,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   fmparser!
-  google-protobuf (~> 3.8)
+  google-protobuf
   pry (~> 0.12)
   rake (~> 10.0)
   rspec (~> 3.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.17)
+  bundler
   fmparser!
   google-protobuf (~> 3.8)
   pry (~> 0.12)
@@ -40,4 +40,4 @@ DEPENDENCIES
   rspec (~> 3.8)
 
 BUNDLED WITH
-   1.17.2
+   2.4.2

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Or install it yourself as:
 
     $ gem install fmparser
 
+## Requirements
+- Ruby 2.7 or higher
+
 ## Usage
 
 `FMParser.parse` parses FieldMask parameter and returns a `FMParser::MessageNode` object.

--- a/fmparser.gemspec
+++ b/fmparser.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry", "~> 0.12"
   spec.add_development_dependency "rspec", "~> 3.8"

--- a/fmparser.gemspec
+++ b/fmparser.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry", "~> 0.12"
   spec.add_development_dependency "rspec", "~> 3.8"
-  spec.add_development_dependency "google-protobuf", "~> 3.8"
+  spec.add_development_dependency "google-protobuf"
 end


### PR DESCRIPTION
## Why
- Use github actions to shorten the time of job exec
  - Github actions can run each test with around 10 seconds in this repo
  - It seems that Travis CI took around 40 seconds to bundle install dependencies: https://github.com/wantedly/fmparser/pull/1/checks?check_run_id=7060078565
- Run test with ruby 2.7 to 3.1 to check version compatibility
- Update deprecated version of bundler
- Update google-protobuf to follow changes
  - google-protobuf 3.8.0 can not be installed with ruby 2.7
```
LoadError:
  cannot load such file -- google/protobuf_c
# ./vendor/bundle/ruby/2.7.0/gems/google-protobuf-3.8.0-x86_64-linux/lib/google/protobuf.rb:51:in `require'
# ./vendor/bundle/ruby/2.7.0/gems/google-protobuf-3.8.0-x86_64-linux/lib/google/protobuf.rb:51:in `rescue in <top (required)>'
# ./vendor/bundle/ruby/2.7.0/gems/google-protobuf-3.8.0-x86_64-linux/lib/google/protobuf.rb:[48](https://github.com/3150/fmparser/actions/runs/3825949378/jobs/6509339446#step:5:49):in `<top (required)>'
# ./spec/support/test_msg.rb:1:in `require'
# ./spec/support/test_msg.rb:1:in `<top (required)>'
# ./spec/fmparser_spec.rb:1:in `require'
# ./spec/fmparser_spec.rb:1:in `<top (required)>'
# ------------------
# --- Caused by: ---
# LoadError:
#   cannot load such file -- google/2.7/protobuf_c
#   ./vendor/bundle/ruby/2.7.0/gems/google-protobuf-3.8.0-x86_64-linux/lib/google/protobuf.rb:[49](https://github.com/3150/fmparser/actions/runs/3825949378/jobs/6509339446#step:5:50):in `require'
```

## What
- Run test with ruby 2.7 to 3.1
- Update bundler to 2.4.2
- Introduce github actions


## Check
All test passed in forked repo: https://github.com/3150/fmparser/actions/runs/3825955463